### PR TITLE
add .prettierignore; ignore all assets

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore assets
+src/assets


### PR DESCRIPTION
### Motivation
Prettier currently checks the format of all files in the `src` directory. The addition of several large, high-resolution images in `src/assets/pictures` has slowed down formatting to a crawl

### Implementation
Add `.prettierignore` to exclude `src/assets` from formatting operations
